### PR TITLE
refactor to put all logic in transfuse

### DIFF
--- a/embedded/src/bert/bert.h
+++ b/embedded/src/bert/bert.h
@@ -20,9 +20,9 @@ struct bert_meminfo {
 
 int  bert_read(int logicalm, uint64_t *data, XFpga* XFpgaInstance);
 int  bert_write(int logicalm, uint64_t *data, XFpga* XfpgaInstance);
-int  bert_write_we(int logicalm, uint64_t *data, XFpga* XfpgaInstance);
+//int  bert_write_we(int logicalm, uint64_t *data, XFpga* XfpgaInstance);
 int  bert_transfuse(int num, struct bert_meminfo *meminfo, XFpga* XFpgaInstance);
-int  bert_transfuse_we(int num, struct bert_meminfo *meminfo, XFpga* XFpgaInstance);
+//int  bert_transfuse_we(int num, struct bert_meminfo *meminfo, XFpga* XFpgaInstance);
 
 void bert_to_logical(int logical,uint32_t *frame_data,uint64_t *logical_data,
 			       int start_addr, int data_length, struct frame_set *the_frame_set);


### PR DESCRIPTION
bert_read and bert_write are just wrappers.
bert_transfuse is now the one that was bert_transfuse_we.
_we versions removed.
